### PR TITLE
Add ChatGPTify

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Impactful scientific papers about GPT-4 and its predecessors.
 - [gpt-cli](https://github.com/CristiVlad25/gpt-cli) - Access GPT3, ChatGPT, and GPT4 straight from your terminal.
 - [Wolverine](https://github.com/biobootloader/wolverine) - Run Python scripts and when they crash, GPT-4 edits them and explains what went wrong.
 - [datasetGPT](https://github.com/radi-cho/datasetGPT) - A command-line interface to generate textual and conversational datasets with LLMs.
-- [ChatGPTify](https://github.com/idilsulo/ChatGPTify) - Spotify playlist generator via ChatGPT.
 - [ChatGPTify](https://github.com/idilsulo/ChatGPTify) - Spotify playlist generator via ChatGPT (and GPT-4)
 
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Impactful scientific papers about GPT-4 and its predecessors.
 - [Wolverine](https://github.com/biobootloader/wolverine) - Run Python scripts and when they crash, GPT-4 edits them and explains what went wrong.
 - [datasetGPT](https://github.com/radi-cho/datasetGPT) - A command-line interface to generate textual and conversational datasets with LLMs.
 - [ChatGPTify](https://github.com/idilsulo/ChatGPTify) - Spotify playlist generator via ChatGPT.
+- [ChatGPTify](https://github.com/idilsulo/ChatGPTify) - Spotify playlist generator via ChatGPT (and GPT-4)
 
 
 ### Community demos

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Impactful scientific papers about GPT-4 and its predecessors.
 - [gpt-cli](https://github.com/CristiVlad25/gpt-cli) - Access GPT3, ChatGPT, and GPT4 straight from your terminal.
 - [Wolverine](https://github.com/biobootloader/wolverine) - Run Python scripts and when they crash, GPT-4 edits them and explains what went wrong.
 - [datasetGPT](https://github.com/radi-cho/datasetGPT) - A command-line interface to generate textual and conversational datasets with LLMs.
+- [ChatGPTify](https://github.com/idilsulo/ChatGPTify) - Spotify playlist generator via ChatGPT.
 
 
 ### Community demos

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Impactful scientific papers about GPT-4 and its predecessors.
 - [gpt-cli](https://github.com/CristiVlad25/gpt-cli) - Access GPT3, ChatGPT, and GPT4 straight from your terminal.
 - [Wolverine](https://github.com/biobootloader/wolverine) - Run Python scripts and when they crash, GPT-4 edits them and explains what went wrong.
 - [datasetGPT](https://github.com/radi-cho/datasetGPT) - A command-line interface to generate textual and conversational datasets with LLMs.
-- [ChatGPTify](https://github.com/idilsulo/ChatGPTify) - Spotify playlist generator via ChatGPT (and GPT-4)
+- [ChatGPTify](https://github.com/idilsulo/ChatGPTify) - Spotify playlist generator via ChatGPT (and GPT-4).
 
 
 ### Community demos


### PR DESCRIPTION
ChatGPTify is a simple tool that connects ChatGPT and Spotify to create playlists based on user prompts directly on your Spotify account. It is built with Python and uses spotipy and chatgpt-wrapper for creating playlists. 

Thank you for your consideration!